### PR TITLE
fix: npm start now uses node instead of nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cover": "jest --coverage",
     "lint": "eslint \"src/**/*.js\"",
-    "start": "nodemon"
+    "start": "cd src && node server.js",
+    "start-dev": "nodemon"
   },
   "author": {
     "name": "Build For SDG",


### PR DESCRIPTION
## Description
The change is for heroku to run the app. npm start-dev will run nodemon instead

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
